### PR TITLE
Fix and test sparse file support

### DIFF
--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -38,7 +38,6 @@ type RestoreOptions struct {
 	Paths              []string
 	Tags               restic.TagLists
 	Verify             bool
-	SparseFiles        bool
 }
 
 var restoreOptions RestoreOptions
@@ -57,7 +56,6 @@ func init() {
 	flags.Var(&restoreOptions.Tags, "tag", "only consider snapshots which include this `taglist` for snapshot ID \"latest\"")
 	flags.StringArrayVar(&restoreOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path` for snapshot ID \"latest\"")
 	flags.BoolVar(&restoreOptions.Verify, "verify", false, "verify restored files content")
-	flags.BoolVar(&restoreOptions.SparseFiles, "sparse", false, "restore files as sparse when possible")
 }
 
 func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
@@ -124,7 +122,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	res, err := restorer.NewRestorer(repo, id, opts.SparseFiles)
+	res, err := restorer.NewRestorer(repo, id)
 	if err != nil {
 		Exitf(2, "creating restorer failed: %v\n", err)
 	}

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -163,7 +163,7 @@ func newTestRepo(content []TestFile) *TestRepo {
 func restoreAndVerify(t *testing.T, tempdir string, content []TestFile) {
 	repo := newTestRepo(content)
 
-	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.idx, false)
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.idx)
 	r.files = repo.files
 
 	r.restoreFiles(context.TODO(), func(path string, err error) {

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -15,9 +15,8 @@ import (
 
 // Restorer is used to restore a snapshot to a directory.
 type Restorer struct {
-	repo        restic.Repository
-	sn          *restic.Snapshot
-	sparseFiles bool
+	repo restic.Repository
+	sn   *restic.Snapshot
 
 	Error        func(location string, err error) error
 	SelectFilter func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool)
@@ -26,10 +25,9 @@ type Restorer struct {
 var restorerAbortOnAllErrors = func(location string, err error) error { return err }
 
 // NewRestorer creates a restorer preloaded with the content from the snapshot id.
-func NewRestorer(repo restic.Repository, id restic.ID, sparseFiles bool) (*Restorer, error) {
+func NewRestorer(repo restic.Repository, id restic.ID) (*Restorer, error) {
 	r := &Restorer{
 		repo:         repo,
-		sparseFiles:  sparseFiles,
 		Error:        restorerAbortOnAllErrors,
 		SelectFilter: func(string, string, *restic.Node) (bool, bool) { return true, true },
 	}
@@ -208,7 +206,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 
 	idx := restic.NewHardlinkIndex()
 
-	filerestorer := newFileRestorer(dst, res.repo.Backend().Load, res.repo.Key(), filePackTraverser{lookup: res.repo.Index().Lookup}, res.sparseFiles)
+	filerestorer := newFileRestorer(dst, res.repo.Backend().Load, res.repo.Key(), filePackTraverser{lookup: res.repo.Index().Lookup})
 
 	// first tree pass: create directories and collect all files to restore
 	err = res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -322,7 +322,7 @@ func TestRestorer(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := NewRestorer(repo, id, false)
+			res, err := NewRestorer(repo, id)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -440,7 +440,7 @@ func TestRestorerRelative(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := NewRestorer(repo, id, false)
+			res, err := NewRestorer(repo, id)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -671,7 +671,7 @@ func TestRestorerTraverseTree(t *testing.T) {
 			defer cleanup()
 			sn, id := saveSnapshot(t, repo, test.Snapshot)
 
-			res, err := NewRestorer(repo, id, false)
+			res, err := NewRestorer(repo, id)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -3,12 +3,16 @@
 package restorer
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
 
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -29,7 +33,7 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 		},
 	})
 
-	res, err := NewRestorer(repo, id, false)
+	res, err := NewRestorer(repo, id)
 	rtest.OK(t, err)
 
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
@@ -58,4 +62,56 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 	if ok1 && ok2 {
 		rtest.Equals(t, s1.Ino, s2.Ino)
 	}
+}
+
+// Test restoring of sparse files.
+//
+// This test does not check whether Truncate was ever used, let alone if it
+// was successful. Check the coverage report for that information.
+func TestRestorerSparseFiles(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	var zeros [1 << 20]byte // 1MB
+
+	target := &fs.Reader{
+		Mode:       0600,
+		Name:       "/zeros",
+		ReadCloser: ioutil.NopCloser(bytes.NewReader(zeros[:])),
+	}
+	sc := archiver.NewScanner(target)
+	err := sc.Scan(context.TODO(), []string{"/zeros"})
+	rtest.OK(t, err)
+
+	arch := archiver.New(repo, target, archiver.Options{})
+	_, id, err := arch.Snapshot(context.Background(), []string{"/zeros"},
+		archiver.SnapshotOptions{})
+
+	res, err := NewRestorer(repo, id)
+	rtest.OK(t, err)
+
+	tempdir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
+
+	filename := filepath.Join(tempdir, "zeros")
+	content, err := ioutil.ReadFile(filename)
+	rtest.OK(t, err)
+
+	rtest.Equals(t, zeros[:], content)
+
+	fi, err := os.Stat(filename)
+	rtest.OK(t, err)
+	st := fi.Sys().(*syscall.Stat_t)
+	if st == nil {
+		return
+	}
+
+	t.Logf("wrote %d bytes file with %d blocks of size %d",
+		len(zeros), st.Blocks, st.Blksize)
 }


### PR DESCRIPTION
I fixed your sparse restore support and added a test to show that it works. As @chrestomanci suggested, this version no longer requires a flag and just tries to Truncate unconditionally, retrying with a Write if the Truncate fails.

If you pull this, the patch should automatically show up in restic/restic#2378.